### PR TITLE
switch to netlify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Markdown String schema
+- Author schema
+- Module schema
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-schemas.powerd6.org

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Schemas used by the powerd6 roleplaying system
 
+[![Netlify Status](https://api.netlify.com/api/v1/badges/5b8476e0-8260-4367-b8db-1962fce55269/deploy-status)](https://app.netlify.com/sites/powerd6-schemas/deploys)
+
+## Organization
+
 Schemas are store under the [`schemas`](schemas/) folder.
 
 Documentation for each schema is available under the [`docs`](docs/) folder.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 Schemas used by the powerd6 roleplaying system
 
-Documentation for each schema is available under the [`docs`](docs/index.md) folder.
+Schemas are store under the [`schemas`](schemas/) folder.
+
+Documentation for each schema is available under the [`docs`](docs/) folder.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# Documentation
+
+Each schema is documented with examples.
+
+Look at the sidebar for the available schemas.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,0 +1,5 @@
+<!-- docs/_sidebar.md -->
+
+* [Author](author.md)
+* [Markdown String](markdown-string.md)
+* [Module](module.md)

--- a/docs/author.md
+++ b/docs/author.md
@@ -16,6 +16,6 @@ The human readable name
 
 ## `biography` (optional)
 
-Type: [markdown-string](./markdown-string.md)
+Type: [markdown-string](markdown-string.md)
 
 A short biography for the author

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,0 @@
-# Documentation
-
-Here are the available schemas
-
-## [Author](author.md)
-
-## [Markdown String](markdown-string.md)
-
-## [Module](module.md)

--- a/docs/markdown-string.md
+++ b/docs/markdown-string.md
@@ -21,7 +21,7 @@ The value inside `[]` is a JSON-path expression that instructs which objects fro
 
 An expression `{.name}[$.content.currency[?(@.id=='gol')]]` will show the `name` property of the object located at `$.content.currency[?(@.id=='gol')`.
 
-In the example shown in [the module documentation](./module.md), this object would be:
+In the example shown in [the module documentation](module.md), this object would be:
 
 ```json
 {

--- a/docs/module.md
+++ b/docs/module.md
@@ -16,13 +16,13 @@ The human readable name
 
 ## `description`
 
-Type: [markdown-string](./markdown-string.md)
+Type: [markdown-string](markdown-string.md)
 
 A description of the module and what it provides
 
 ## `author`
 
-Type: array([author](./author.md))
+Type: array([author](author.md))
 
 The list of authors of the module
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>powerd6 - Schemas</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="description" content="Description" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0"
+    />
+    <link
+      rel="stylesheet"
+      href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css"
+    />
+    <!-- Changelog -->
+    <link
+      rel="stylesheet"
+      href="//cdn.jsdelivr.net/npm/docsify-changelog-plugin@latest/dist/style.css"
+    />
+    <link
+      rel="stylesheet"
+      href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css"
+    />
+  </head>
+  <body>
+    <nav></nav>
+    <div data-app id="main">Please wait...</div>
+    <script>
+      window.$docsify = {
+        el: "#main",
+        basePath: "/docs/",
+        name: "powerd6/schemas",
+        repo: "https://github.com/powerd6/schemas",
+        loadSidebar: true,
+        subMaxLevel: 2,
+        auto2top: true,
+        loadNavbar: false, // important for changelog
+        changelog: "CHANGELOG.md",
+      };
+    </script>
+    <!-- Docsify v4 -->
+    <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+    <!-- Copy code -->
+    <script src="//cdn.jsdelivr.net/npm/docsify-copy-code/dist/docsify-copy-code.min.js"></script>
+    <!-- Mermaid plugin -->
+    <script src="//unpkg.com/mermaid/dist/mermaid.js"></script>
+    <script src="//unpkg.com/docsify-mermaid@latest/dist/docsify-mermaid.js"></script>
+    <script>
+      mermaid.initialize({ startOnLoad: true });
+    </script>
+    <!-- CHANGELOG -->
+    <script src="https://cdn.jsdelivr.net/npm/docsify-changelog-plugin@latest/dist/index.js"></script>
+  </body>
+</html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,6 @@
 
 
 [[headers]]
-  for = "/schema/*.json"
+  for = "/schemas/*.json"
   [headers.values]
     content-type = "application/schema+json"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  command = "" # Blank because docsify doesn't need to build
+
+
+[[headers]]
+  for = "/schema/*.json"
+  [headers.values]
+    content-type = "application/schema+json"

--- a/schemas/author.json
+++ b/schemas/author.json
@@ -1,7 +1,7 @@
 {
   "title": "Author",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "http://powerd6.org/schemas/author.json",
+  "$id": "http://schemas.powerd6.org/schemas/author.json",
   "type": "object",
   "required": ["id", "name"],
   "properties": {
@@ -12,7 +12,7 @@
       "type": "string"
     },
     "biography": {
-      "$ref": "https://powerd6.org/schemas/markdown-string"
+      "$ref": "https://schemas.powerd6.org/markdown-string.json"
     }
   },
   "additionalProperties": false

--- a/schemas/markdown-string.json
+++ b/schemas/markdown-string.json
@@ -1,7 +1,7 @@
 {
   "title": "Markdown String",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "http://powerd6.org/schemas/markdown-string.json",
+  "$id": "http://schemas.powerd6.org/schemas/markdown-string.json",
   "type": "string",
   "$comment": "A markdown field",
   "additionalProperties": false

--- a/schemas/module.json
+++ b/schemas/module.json
@@ -1,7 +1,7 @@
 {
   "title": "Module",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "http://powerd6.org/schemas/module.json",
+  "$id": "http://schemas.powerd6.org/schemas/module.json",
   "type": "object",
   "required": ["id", "name", "description", "authors", "models"],
   "properties": {
@@ -12,12 +12,12 @@
       "type": "string"
     },
     "description": {
-      "$ref": "https://powerd6.org/schemas/markdown-string"
+      "$ref": "https://schemas.powerd6.org/markdown-string.json"
     },
     "authors": {
       "type": "array",
       "items": {
-        "$ref": "https://powerd6.org/schemas/author"
+        "$ref": "https://schemas.powerd6.org/author.json"
       }
     },
     "models": {


### PR DESCRIPTION
Switch to Netlify using [docsify](https://docsify.js.org) to render documentation.

Netlify was chosen because it enables content-type header rewriting.